### PR TITLE
Bumps node version to 9.2.0

### DIFF
--- a/mac
+++ b/mac
@@ -197,7 +197,7 @@ number_of_cores=$(sysctl -n hw.ncpu)
 bundle config --global jobs $((number_of_cores - 1))
 
 fancy_echo "Installing latest Node..."
-install_asdf_language "nodejs" "7.8.0"
+install_asdf_language "nodejs" "9.2.0"
 
 if [ -f "$HOME/.laptop.local" ]; then
   fancy_echo "Running your customizations from ~/.laptop.local ..."


### PR DESCRIPTION
This installs and set node 9.2.0 as the global version. New laptops can just run this script as normal. Engineers who've configured their laptop beyond this script will have to run the following from their `flatbook` repo:
```
yarn global add yarn
asdf install nodejs 9.2.0
asdf global nodejs 9.2.0
yarn install
```