### PR TITLE
Add chromedriver, required for feature specs.

### DIFF
--- a/mac
+++ b/mac
@@ -144,6 +144,9 @@ cask "gpg-suite"
 # Databases
 brew "postgres", restart_service: :changed
 brew "redis", restart_service: :changed
+
+# Testing Support
+brew "chromedriver"
 EOF
 
 if brew list | grep --silent "qt@5.5"; then


### PR DESCRIPTION
Chromedriver is required in order to run the specs under `spec/features/` in the Flatbook repo. When the specs fail they provide a link to download/install chromedriver manually, but I think it would be easier/cleaner to just install it with homebrew via laptop setup.

This PR changes the setup script to install chromedriver.