### PR TITLE
mac: Add SKIP_ZSH flag

### DIFF
--- a/mac
+++ b/mac
@@ -3,6 +3,16 @@
 # Be prepared to turn your laptop (or desktop, no haters here)
 # into an awesome development machine.
 
+SKIP_ZSH=0
+SHELL_CHANGES=()
+while getopts "z" opt; do
+  case "$opt" in
+    "z")
+      SKIP_ZSH=1
+      ;;
+  esac
+done
+
 fancy_echo() {
   local fmt="$1"; shift
 
@@ -14,11 +24,18 @@ append_to_zshrc() {
   local text="$1" zshrc
   local skip_new_line="${2:-0}"
 
+  if [[ "${SKIP_ZSH}" == 1 ]]; then
+    SHELL_CHANGES+=("$text")
+    return
+  fi
+
   if [ -w "$HOME/.zshrc.local" ]; then
     zshrc="$HOME/.zshrc.local"
   else
     zshrc="$HOME/.zshrc"
   fi
+
+  touch "${zshrc}"
 
   if ! grep -Fqs "$text" "$zshrc"; then
     if [ "$skip_new_line" -eq 1 ]; then
@@ -32,14 +49,8 @@ append_to_zshrc() {
 # shellcheck disable=SC2154
 trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
 
-set -e
-
 if [ ! -d "$HOME/.bin/" ]; then
   mkdir "$HOME/.bin"
-fi
-
-if [ ! -f "$HOME/.zshrc" ]; then
-  touch "$HOME/.zshrc"
 fi
 
 # shellcheck disable=SC2016
@@ -77,7 +88,9 @@ case "$SHELL" in
     fi
     ;;
   *)
-    update_shell
+    if [[ "${SKIP_ZSH}" != 1 ]]; then
+      update_shell
+    fi
     ;;
 esac
 
@@ -91,15 +104,15 @@ gem_install_or_update() {
 
 if ! command -v brew >/dev/null; then
   fancy_echo "Installing Homebrew ..."
-    curl -fsS \
-      'https://raw.githubusercontent.com/Homebrew/install/master/install' | ruby
+  curl -fsS \
+    'https://raw.githubusercontent.com/Homebrew/install/master/install' | ruby
 
-    append_to_zshrc '# recommended by brew doctor'
+  append_to_zshrc '# recommended by brew doctor'
 
-    # shellcheck disable=SC2016
-    append_to_zshrc 'export PATH="/usr/local/bin:$PATH"' 1
+  # shellcheck disable=SC2016
+  append_to_zshrc 'export PATH="/usr/local/bin:$PATH"' 1
 
-    PATH="/usr/local/bin:$PATH" # For the current session as well
+  PATH="/usr/local/bin:$PATH" # For the current session as well
 fi
 
 if brew list | grep -Fq brew-cask; then
@@ -109,7 +122,8 @@ fi
 
 fancy_echo "Updating Homebrew formulae ..."
 brew update --force # https://github.com/Homebrew/brew/issues/1151
-brew bundle --file=- <<EOF
+
+read -r -d '' BREW_BUNDLE_FILE <<EOF
 tap "thoughtbot/formulae"
 tap "homebrew/services"
 tap "universal-ctags/universal-ctags"
@@ -123,7 +137,6 @@ brew "reattach-to-user-namespace"
 brew "the_silver_searcher"
 brew "tmux"
 brew "vim"
-brew "zsh"
 
 # Heroku
 brew "heroku"
@@ -148,6 +161,19 @@ brew "redis", restart_service: :changed
 # Testing Support
 cask "chromedriver"
 EOF
+
+# Install zsh if the -z flag is not specified.
+if [[ "${SKIP_ZSH}" != 1 ]]; then
+    # Append the zsh into the bundle file variable
+    read -d '' BREW_BUNDLE_FILE <<EOF
+${BREW_BUNDLE_FILE}
+
+# More unix
+brew "zsh"
+EOF
+fi
+
+echo "${BREW_BUNDLE_FILE}" | brew bundle --file=-
 
 if brew list | grep --silent "qt@5.5"; then
   fancy_echo "Symlink qmake binary to /usr/local/bin for Capybara Webkit..."
@@ -210,5 +236,16 @@ if [ -f "$HOME/.laptop.local" ]; then
   . "$HOME/.laptop.local"
 fi
 
-SHELL=$( which zsh )
-$SHELL -l
+fancy_echo "Script complete!"
+
+if [[ "${SKIP_ZSH}" == 1 ]]; then
+  fancy_echo "Since zsh was not installed, please add the following to your shell rc:"
+  echo ""
+  for line in "${SHELL_CHANGES[@]}"; do
+    echo $line;
+  done
+else
+  # Switch to zsh
+  SHELL=$( which zsh )
+  $SHELL -l
+fi


### PR DESCRIPTION
When SKIP_ZSH is specified:
- do not install the 'zsh' homebrew package,
- do not set the ~/.zshrc file,
- do not attempt to switch to zsh at the end of the installation, and
- prompt the user to manually modify their shell's rc file.

At the moment, the flag is not overtly documented as the installation
instructions recommend all engineers to read the script before execution.