### PR TITLE
Update brew heroku command.

### DIFF
--- a/mac
+++ b/mac
@@ -87,7 +87,7 @@ brew "tmux"
 brew "vim"
 
 # Heroku
-brew "heroku"
+brew install heroku/brew/heroku
 brew "parity"
 
 # Image manipulation


### PR DESCRIPTION
The heroku formula for homebrew has been updated to "heroku/brew/heroku".
![screen shot 2018-11-06 at 9 18 01 am](https://user-images.githubusercontent.com/774846/48081433-e654bf80-e1a4-11e8-8972-0d2f6356e575.png)
