### PR TITLE
Update mac script to fix brew command warning and failures

### DIFF
--- a/mac
+++ b/mac
@@ -75,7 +75,6 @@ read -r -d '' BREW_BUNDLE_FILE <<EOF
 tap "thoughtbot/formulae"
 tap "homebrew/services"
 tap "universal-ctags/universal-ctags"
-tap "caskroom/cask"
 
 # Unix
 brew "universal-ctags", args: ["HEAD"]
@@ -87,14 +86,15 @@ brew "tmux"
 brew "vim"
 
 # Heroku
-brew "heroku/brew/heroku"
+tap "heroku/brew"
+brew "heroku"
 brew "parity"
 
 # Image manipulation
 brew "imagemagick"
 
 # Testing
-brew "qt@5.5" if MacOS::Xcode.installed?
+brew "qt" if MacOS::Xcode.installed?
 
 # Programming language prerequisites and package managers
 brew "libyaml" # should come after openssl
@@ -113,10 +113,10 @@ EOF
 
 echo "${BREW_BUNDLE_FILE}" | brew bundle --file=-
 
-if brew list | grep --silent "qt@5.5"; then
+if brew list | grep --silent "qt"; then
   fancy_echo "Symlink qmake binary to /usr/local/bin for Capybara Webkit..."
-  brew unlink qt@5.5
-  brew link --force qt@5.5
+  brew unlink qt
+  brew link --force qt
 fi
 
 fancy_echo "Update heroku binary..."


### PR DESCRIPTION
See issue https://github.com/Flatbook/laptop/issues/14:
* Removed tap caskroom/cask: brew cask is available natively
* Modified heroku and qt install commands

I ensured that:
* brew cask is working with latest version of homebrew
```
$ brew --version
Homebrew 2.1.14
Homebrew/homebrew-core (git revision 1a175; last commit 2019-10-16)
Homebrew/homebrew-cask (git revision 5db6b8; last commit 2019-10-17)

$ brew cask
Homebrew Cask provides a friendly CLI workflow for the administration
of macOS applications distributed as binaries.

Commands:
[...]
```
* `heroku` command line tool is availble
```
$ heroku --version
heroku/7.33.3 darwin-x64 node-v11.14.0
```
* QT is working by checking the `qmake` command line tool:
```
$ qmake --version
QMake version 3.1
Using Qt version 5.13.1 in /usr/local/Cellar/qt/5.13.1/lib
```