### PR TITLE
Update ruby 2.4.1 -> 2.5.8

### DIFF
--- a/mac
+++ b/mac
@@ -135,8 +135,9 @@ echo 'export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES'  >>~/.bash_profile >>~/.zs
 
 echo 'eval "$(rbenv init -)"' >>~/.bash_profile >>~/.zshrc
 
-fancy_echo "Installing Ruby 2.4.1..."
-rbenv install "2.4.1" --skip-existing
+fancy_echo "Installing Ruby 2.5.8..."
+brew upgrade ruby-build
+rbenv install "2.5.8" --skip-existing
 
 fancy_echo "Installing nvm..."
 brew install nvm


### PR DESCRIPTION
## Why the PR?
Trying to run rails or rake on flatbook yields an error about mismatching versions between what is installed locally using this script, and what is expected from flatbook.

## What the PR does?
Installs a ruby version that matches flatbook's version (https://github.com/Flatbook/flatbook/pull/11571)

✅ Tested manually by running the updated `mac` script and running a `rake db:migrate` in flatbook successfully